### PR TITLE
Updating GitHub action script for docker automation

### DIFF
--- a/.github/workflows/github_actions_CD.yml
+++ b/.github/workflows/github_actions_CD.yml
@@ -4,11 +4,11 @@
 
 #Purpose:
 #GitHub Actions is a continuous integration and continuous delivery (CI/CD)
-#platform that allows to automate the build, test, and deployment pipeline. The
+#platform that allows to automate the build, test, and deployment pipeline.
 #The purpose of this file is to give instructions to GitHub on how to do the
 #image deployment to Docker Hub.
-#Author:
-#Cedric H. David, 2022-2022.
+#Authors:
+#Cedric H. David, Alex Christopher Lim, 2022-2022.
 
 
 #*******************************************************************************
@@ -66,7 +66,7 @@ jobs:
            uses: docker/build-push-action@v3
            with:
               push: true
-              tags: ${{ secrets.DOCKER_HUB_NAME }}/rrr:latest
+              tags: ${{ secrets.DOCKER_HUB_NAME }}/rrr:'v*', ${{ secrets.DOCKER_HUB_NAME }}/rrr:'20*', ${{ secrets.DOCKER_HUB_NAME }}/rrr:latest
 
 
 #*******************************************************************************

--- a/.github/workflows/github_actions_CD.yml
+++ b/.github/workflows/github_actions_CD.yml
@@ -51,6 +51,13 @@ jobs:
               echo "The shell used is $SHELL"
 
       #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      #Extracting version metadata
+      #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+         - name: Get the version
+           id: get_version
+           run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+
+      #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       #Login to Docker Hub
       #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
          - name: Login to Docker Hub
@@ -66,7 +73,7 @@ jobs:
            uses: docker/build-push-action@v3
            with:
               push: true
-              tags: ${{ secrets.DOCKER_HUB_NAME }}/rrr:${{ github.ref }}
+              tags: ${{ secrets.DOCKER_HUB_NAME }}/rrr:${{ steps.get_version.outputs.VERSION }}
 
 
 #*******************************************************************************

--- a/.github/workflows/github_actions_CD.yml
+++ b/.github/workflows/github_actions_CD.yml
@@ -53,21 +53,9 @@ jobs:
       #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       #Extracting version metadata
       #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-         - name: Checkout
-           uses: actions/checkout@v2
-
-         - name: Log into Container registry
-           uses: docker/login-action@v2
-           with:
-             registry: ghrc.io
-             username: ${{ github.actor }}
-             password: ${{ secrets.GITHUB_TOKEN }}
-
-         - name: Extract metadata for the Docker image
-           id: meta
-           uses: docker/login-action@v2
-           with:
-             images: ${{ secrets.DOCKER_HUB_NAME }}/rrr
+         - name: Get the version
+           id: get_version
+           run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
 
       #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       #Login to Docker Hub
@@ -84,10 +72,8 @@ jobs:
          - name: Build and push
            uses: docker/build-push-action@v3
            with:
-              context: .
               push: true
-              tags: ${{ secrets.DOCKER_HUB_NAME }}/rrr:${{ steps.meta.outputs.tags }}, ${{ secrets.DOCKER_HUB_NAME }}/rrr:latest
-              labels: ${{ steps.meta.outputs.labels }}
+              tags: ${{ secrets.DOCKER_HUB_NAME }}/rrr:${{ steps.get_version.outputs.VERSION }}
 
 
 #*******************************************************************************

--- a/.github/workflows/github_actions_CD.yml
+++ b/.github/workflows/github_actions_CD.yml
@@ -51,6 +51,25 @@ jobs:
               echo "The shell used is $SHELL"
 
       #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+      #Extracting version metadata
+      #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+         - name: Checkout
+           uses: actions/checkout@v2
+
+         - name: Log into Container registry
+           uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+           with:
+             registry: ${{ secrets.DOCKER_HUB_NAME }}/rrr
+             username: ${{ secrets.DOCKER_HUB_NAME }}
+             password: ${{ secrets.DOCKER_HUB_TOKN }}
+
+         - name: Extract metadata for the Docker image
+           id: meta
+           uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+           with:
+             images: ${{ secrets.DOCKER_HUB_NAME }}/rrr
+
+      #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       #Login to Docker Hub
       #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
          - name: Login to Docker Hub
@@ -65,8 +84,10 @@ jobs:
          - name: Build and push
            uses: docker/build-push-action@v3
            with:
+              context: .
               push: true
-              tags: ${{ secrets.DOCKER_HUB_NAME }}/rrr:'v*', ${{ secrets.DOCKER_HUB_NAME }}/rrr:'20*', ${{ secrets.DOCKER_HUB_NAME }}/rrr:latest
+              tags: ${{ secrets.DOCKER_HUB_NAME }}/rrr:${{ steps.meta.outputs.tags }}, ${{ secrets.DOCKER_HUB_NAME }}/rrr:latest
+              labels: ${{ steps.meta.outputs.labels }}
 
 
 #*******************************************************************************

--- a/.github/workflows/github_actions_CD.yml
+++ b/.github/workflows/github_actions_CD.yml
@@ -51,13 +51,6 @@ jobs:
               echo "The shell used is $SHELL"
 
       #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-      #Extracting version metadata
-      #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-         - name: Get the version
-           id: get_version
-           run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
-
-      #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       #Login to Docker Hub
       #- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
          - name: Login to Docker Hub
@@ -73,7 +66,7 @@ jobs:
            uses: docker/build-push-action@v3
            with:
               push: true
-              tags: ${{ secrets.DOCKER_HUB_NAME }}/rrr:${{ steps.get_version.outputs.VERSION }}
+              tags: ${{ secrets.DOCKER_HUB_NAME }}/rrr:${{ github.ref }}
 
 
 #*******************************************************************************

--- a/.github/workflows/github_actions_CD.yml
+++ b/.github/workflows/github_actions_CD.yml
@@ -57,15 +57,15 @@ jobs:
            uses: actions/checkout@v2
 
          - name: Log into Container registry
-           uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+           uses: docker/login-action@v2
            with:
-             registry: ${{ secrets.DOCKER_HUB_NAME }}/rrr
-             username: ${{ secrets.DOCKER_HUB_NAME }}
-             password: ${{ secrets.DOCKER_HUB_TOKN }}
+             registry: ghrc.io
+             username: ${{ github.actor }}
+             password: ${{ secrets.GITHUB_TOKEN }}
 
          - name: Extract metadata for the Docker image
            id: meta
-           uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+           uses: docker/login-action@v2
            with:
              images: ${{ secrets.DOCKER_HUB_NAME }}/rrr
 


### PR DESCRIPTION
This will directly extract the version metadata from GitHub to automatically make the push to Docker Hub with the corresponding tag.